### PR TITLE
Parameterize gnuplot binary name

### DIFF
--- a/eplot
+++ b/eplot
@@ -60,6 +60,7 @@ require 'tempfile'
 $Version="2.07 03.05.2007"
 $TextViewer="cat"
 $GnuPlot4OrNewer=true
+$GnuPlotBin="gnuplot"
 
 # **************************************************************************
 # VARIOUS CONSTANTS
@@ -399,7 +400,7 @@ class Controller
 		# ---- print the options
 		com="echo '\n"+getStyleString+@oc["MiscOptions"]
 		com=com+"set multiplot;\n" if doMultiPlot
-		com=com+"plot "+@oc["Range"]+comString+"\n'| gnuplot -persist"
+		com=com+"plot "+@oc["Range"]+comString+"\n'| "+$GnuPlotBin+" -persist"
 		printAndRun(com)
 		# ---- convert to PDF
 		if @oc["DoPDF"]


### PR DESCRIPTION
Thanks for the nice tool.

I have packaged it for inclusion in [MacPorts](https://www.macports.org/), and one thing I had to do was patch the `gnuplot` invocation to allow customizing the binary path. (The reason for this is that packages installed by MacPorts should depend on and use other MacPorts-packaged tools, so we have to use e.g. `/opt/local/bin/gnuplot` instead of just `gnuplot` to ensure we use the right version.)

This PR parameterizes the `gnuplot` binary name to make it easier for packagers to adjust.